### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ What you will progressively learn:
 
 ```bash
 # Clone the repository
-git https://github.com/YOUR_USERNAME/workshop-robust-hyperparam-tuning.git
+git https://github.com/jusugac1/workshop-robust-hyperparam-tuning.git
 
 cd workshop-robust-hyperparam-tuning
 ```

--- a/notebooks/2.2-pandera-explain.ipynb
+++ b/notebooks/2.2-pandera-explain.ipynb
@@ -78,7 +78,7 @@
    "id": "73ab82cf",
    "metadata": {},
    "source": [
-    "Pandera is a good way to validate to validate the quality of the data. We highly recommend using it before you train your model.\n",
+    "Pandera is a good way to validate the quality of the data. We highly recommend using it before you train your model.\n",
     "\n",
     "Let's take a first example where you want to validate a dataframe. There are 3 columns with different types we want to validate: int, float and string. To do so, you first define a `pa.DataFrameSchema()` in which you will define the columns using `pa.Column(<type>)`."
    ]
@@ -1561,7 +1561,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv (3.13.2)",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
Corrects two typos: 

1. One un readme which was providing a wrong path to clone de repository
2. One in the 2.2-pandera-explain.ipynb file where two words were repeated twice